### PR TITLE
Add OpenAI image rating script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ Your local instance of Chatbot UI should now be running at [http://localhost:300
 
 You can view your backend GUI at [http://localhost:54323/project/default/editor](http://localhost:54323/project/default/editor).
 
+### 7. Rate graphics (optional)
+
+If you want to quickly rate a folder of images with GPT-4 Vision, run:
+
+```bash
+npm run rate-images -- <path/to/directory>
+```
+
+Each image file will be sent to OpenAI and a score from **1** to **10** will be printed to the console. Make sure the `OPENAI_API_KEY` environment variable is set before running the command.
+
 ## Hosted Quickstart
 
 Follow these steps to get your own Chatbot UI instance running in the cloud.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "db-types": "supabase gen types typescript --local > supabase/types.ts",
     "db-pull": "supabase db remote commit",
     "db-push": "supabase db push",
-    "test": "jest"
+    "test": "jest",
+    "rate-images": "ts-node scripts/rate-images.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.18.0",

--- a/scripts/rate-images.ts
+++ b/scripts/rate-images.ts
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import path from 'path'
+import { OpenAI } from 'openai'
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+async function rateImage(filePath: string): Promise<string> {
+  const ext = path.extname(filePath).replace('.', '') || 'png'
+  const b64 = fs.readFileSync(filePath, { encoding: 'base64' })
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4-vision-preview',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Rate the quality of this graphic on a scale of 1-10. Only respond with the number.'
+          },
+          {
+            type: 'image_url',
+            image_url: `data:image/${ext};base64,${b64}`
+          }
+        ]
+      }
+    ],
+    max_tokens: 5
+  })
+
+  return response.choices[0].message.content?.trim() || 'N/A'
+}
+
+async function main() {
+  const dir = process.argv[2]
+  if (!dir) {
+    console.error('Usage: ts-node scripts/rate-images.ts <directory>')
+    process.exit(1)
+  }
+
+  const files = fs.readdirSync(dir).filter(f => /\.(png|jpe?g|gif)$/i.test(f))
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+    try {
+      const rating = await rateImage(filePath)
+      console.log(`${file}: ${rating}`)
+    } catch (err: any) {
+      console.error(`${file}: Failed to rate - ${err.message}`)
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Unexpected error', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add `rate-images` helper script to score graphics via GPT-4 Vision
- expose the new tool through npm scripts

## Testing
- `npm test` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68696b02677483339efa089014cc606f